### PR TITLE
Set log level of same line logger in constructor

### DIFF
--- a/sap_document_classification_client/http_client_base.py
+++ b/sap_document_classification_client/http_client_base.py
@@ -29,6 +29,7 @@ class CommonClient:
         single_line_stream = logging.StreamHandler()
         single_line_stream.terminator = ''
         self.same_line_logger.addHandler(single_line_stream)
+        self.same_line_logger.setLevel(logging_level)
         headers = {'Authorization': 'Bearer {}'.format(self.get_access_token(client_id, client_secret, uaa_url))}
         if base_url[-1] != '/':
             base_url += '/'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
   name='sap-document-classification-client',
   packages=['sap_document_classification_client'],
-  version='0.1.4',
+  version='0.1.5',
   license='apache-2.0',
   description='Python client library for convenient usage of SAP Document Classification service REST API',
   author='Alexander Bolshakov',


### PR DESCRIPTION
Bug fixed where log level of one logger was not set in the CommonClient constructor leading to unintended behaviour.

Please review. I think that is all that is needed?
Will then try to execute the build process to push this to PyPI so that we can then use the new version set in this PR to get rid of the . logs.